### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   def index
-    @items = Item.includes(:purchase).all.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
-  has_one :purchase
+  # has_one :purchase
   has_one_attached :image
 
   validates :image, presence: true

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -1,4 +1,4 @@
-class Purchase < ApplicationRecord
-  belongs_to :item
-  belongs_to :user
-end
+# class Purchase < ApplicationRecord
+# belongs_to :item
+# belongs_to :user
+# end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,5 +13,5 @@ class User < ApplicationRecord
   validates :birthday, presence: true
 
   has_many :items
-  has_many :purchases
+  # has_many :purchases
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,9 +131,9 @@
       <%# if @items.present? %>
       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+          <%= link_to (image_tag item.image, class: "item-img"), item_path(item.id) if item.image.attached? %>
 
           <% if item.purchase.present? %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,12 +135,12 @@
         <div class='item-img-content'>
           <%= link_to (image_tag item.image, class: "item-img"), item_path(item.id) if item.image.attached? %>
 
-          <% if item.purchase.present? %>
+          <%# if item.purchase.present? %>
 
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <% end %>
+          <%# end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,8 +133,7 @@
       <li class='list'>
         <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
-          <%= link_to (image_tag item.image, class: "item-img"), item_path(item.id) if item.image.attached? %>
-
+        <%= image_tag item.image, class: "item-img" if item.image.attached? %>
           <%# if item.purchase.present? %>
 
           <div class='sold-out'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,76 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.itemname %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      
+      <% if @item.purchase.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
+      <% end %>
+
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_responsibility.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? && @item.purchase.present? %>
 
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <% if current_user.id == item.user_id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <% else %>
 
+        <%# 商品が売れていない場合はこちらを表示しましょう %>
+        <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+       
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <% end %>
+
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+      <%end%>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= "#{@item.user.lastname_kanji} #{@item.user.firstname_kanji}" %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_responsibility.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_duration.name %></td>
         </tr>
       </tbody>
     </table>
@@ -104,7 +113,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name%>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        <%= @item.price %>
+        ¥<%= @item.price %>
       </span>
       <span class="item-postage">
         <%= @item.shipping_fee_responsibility.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -10,11 +10,11 @@
       <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       
-      <% if @item.purchase.present? %>
+      <%# if @item.purchase.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%#end %>
 
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
@@ -28,9 +28,9 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && @item.purchase.present? %>
+    <% if user_signed_in? #&& @item.purchase.present? %>
 
-      <% if current_user.id == item.user_id %>
+      <% if current_user.id == @item.user_id %>
       <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
       <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
@@ -53,7 +53,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "#{@item.user.lastname_kanji} #{@item.user.firstname_kanji}" %></td>
+          <td class="detail-value"><%= @item.user.nickname%></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+    
       
       <%# if @item.purchase.present? %>
       <div class="sold-out">
@@ -16,7 +16,7 @@
       </div>
       <%#end %>
 
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -27,7 +27,7 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+   
     <% if user_signed_in? #&& @item.purchase.present? %>
 
       <% if current_user.id == @item.user_id %>
@@ -36,15 +36,15 @@
       <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
       <% else %>
 
-        <%# 商品が売れていない場合はこちらを表示しましょう %>
+      
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
        
 
       <% end %>
 
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    
       <%end%>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -112,9 +112,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name%>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/db/migrate/20240415075108_create_purchases.rb
+++ b/db/migrate/20240415075108_create_purchases.rb
@@ -1,11 +1,11 @@
-class CreatePurchases < ActiveRecord::Migration[7.0]
-  def change
-    create_table :purchases do |t|
+#class CreatePurchases < ActiveRecord::Migration[7.0]
+  #def change
+    #create_table :purchases do |t|
 
-      t.references :user, null: false, foreign_key: true
-      t.references :item, null: false, foreign_key: true
+      #t.references :user, null: false, foreign_key: true
+      #t.references :item, null: false, foreign_key: true
 
-      t.timestamps
-    end
-  end
-end
+      #t.timestamps
+    #end
+  #end
+#end


### PR DESCRIPTION
ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/e63ac6d36b99f87321bc0e6ecd167beb
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/488e59b916b60043be720162414b84d9
ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
https://gyazo.com/488e59b916b60043be720162414b84d9
ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/d439cb7e70de05cf3bdf7a1c296d0bd3

what
商品詳細表示機能の実装をしていた
why
この機能を実装することでユーザーが商品の詳細を知ることができ、購入に繋げることができるから